### PR TITLE
Add initial YAML handling and validation functions

### DIFF
--- a/openstack_tests_list/list_allowed.py
+++ b/openstack_tests_list/list_allowed.py
@@ -1,0 +1,15 @@
+import yaml
+
+def load_yaml(file_path):
+    with open(file_path, 'r') as file:
+        return yaml.safe_load(file)
+
+def get_allowed_tests(file_path):
+    data = load_yaml(file_path)
+    allowed_tests = {}
+    for group in data.get('groups', []):
+        name = group['name']
+        tests = group['tests']
+        releases = group['releases']
+        allowed_tests[name] = {'tests': tests, 'releases': releases}
+    return allowed_tests

--- a/openstack_tests_list/list_skipped.py
+++ b/openstack_tests_list/list_skipped.py
@@ -1,0 +1,16 @@
+import yaml
+
+def load_yaml(file_path):
+    with open(file_path, 'r') as file:
+        return yaml.safe_load(file)
+
+def get_skipped_tests(file_path):
+    data = load_yaml(file_path)
+    skipped_tests = {}
+    for failure in data.get('known_failures', []):
+        test = failure['test']
+        deployment = failure['deployment']
+        releases = failure['releases']
+        jobs = failure['jobs']
+        skipped_tests[test] = {'deployment': deployment, 'releases': releases, 'jobs': jobs}
+    return skipped_tests

--- a/openstack_tests_list/validate.py
+++ b/openstack_tests_list/validate.py
@@ -1,0 +1,29 @@
+import yaml
+from cliff.command import Command
+import validators
+
+class Validate(Command):
+    def take_action(self, parsed_args):
+        with open(parsed_args.file, 'r') as yaml_file:
+            try:
+                content = yaml.safe_load(yaml_file)
+            except yaml.YAMLError as e:
+                self.app.log.error(f"Error parsing YAML file: {e}")
+                return
+
+        if 'known_failures' in content:
+            self.validate_skiplist(content['known_failures'])
+        elif 'groups' in content:
+            self.validate_allowlist(content['groups'])
+        else:
+            self.app.log.error("Invalid format: Missing 'known_failures' or 'groups' key")
+
+    def validate_skiplist(self, skiplist):
+        for item in skiplist:
+            if 'test' not in item or not validators.url(item.get('lp', '')):
+                self.app.log.error(f"Invalid skiplist item: {item}")
+
+    def validate_allowlist(self, allowlist):
+        for group in allowlist:
+            if 'name' not in group or 'tests' not in group:
+                self.app.log.error(f"Invalid allowlist group: {group}")


### PR DESCRIPTION
Add initial YAML handling and validation functions

- Implemented `list_allowed.py` to handle and parse allowlist YAML files.
  - Includes functions to load YAML files and extract allowed tests.

- Implemented `list_skipped.py` to handle and parse skiplist YAML files.
  - Includes functions to load YAML files and extract skipped tests.

- Implemented `validate.py` to validate the structure and content of YAML files.
  - Includes validation for both allowlist and skiplist YAML structures.

These files form the core functionality for managing and validating skiplists and allowlists.