### PR TITLE
Add CLI entry point and commands to main.py

### DIFF
--- a/openstack_tests_list/main.py
+++ b/openstack_tests_list/main.py
@@ -1,0 +1,40 @@
+import click
+from openstack_tests_list.list_allowed import get_allowed_tests
+from openstack_tests_list.list_skipped import get_skipped_tests
+from openstack_tests_list.validate import Validate
+
+
+@click.group()
+def cli():
+    pass
+
+
+@cli.command()
+@click.option("--file", required=True, type=click.Path(exists=True))
+def validate(file):
+    validator = Validate(None, None)
+    # Create a mock object to pass as args
+    args = type("obj", (object,), {"file": file})
+    validator.take_action(args)
+
+
+@cli.command()
+@click.option("--file", required=True, type=click.Path(exists=True))
+def list_allowed(file):
+    allowed_tests = get_allowed_tests(file)
+    click.echo(allowed_tests)
+
+
+@cli.command()
+@click.option("--file", required=True, type=click.Path(exists=True))
+def list_skipped(file):
+    skipped_tests = get_skipped_tests(file)
+    click.echo(skipped_tests)
+
+
+def main():
+    cli()
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
Add CLI entry point and commands to main.py

- Implemented CLI using Click in main.py.
- Added `validate` command to validate YAML files for allowlist and skiplist.
- Added `list_allowed` command to list tests from the allowlist YAML file.
- Added `list_skipped` command to list tests from the skiplist YAML file.
- Defined the `main` function as the entry point for the CLI.

This commit sets up the primary command-line interface for the openstack-tests-list, enabling users to validate and list tests from YAML files.