### PR TITLE
Add manual trigger for CI via PR comments

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   lint:
@@ -14,9 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        run: |
-          git clone https://github.com/${{ github.repository }} .
-        shell: bash
+        uses: actions/checkout@v2
 
       - name: Set up Python
         run: |

--- a/.github/workflows/comment-trigger.yaml
+++ b/.github/workflows/comment-trigger.yaml
@@ -1,0 +1,41 @@
+name: Trigger CI on PR Comment
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  recheck:
+    if: ${{ github.event.issue.pull_request }}  # Only run if the comment is on a PR
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check if the comment is 'recheck'
+      if: contains(github.event.comment.body, 'recheck')
+      run: echo "Comment is recheck"
+
+    - name: Trigger CI workflow
+      if: contains(github.event.comment.body, 'recheck')
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const { owner, repo } = context.repo;
+          const pull_number = context.issue.number;
+
+          const { data: pullRequest } = await github.pulls.get({
+            owner,
+            repo,
+            pull_number
+          });
+
+          const ref = pullRequest.head.ref;
+
+          await github.actions.createWorkflowDispatch({
+            owner,
+            repo,
+            workflow_id: 'ci.yaml',
+            ref,
+            inputs: {}
+          });
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Added `workflow_dispatch` event to `ci.yaml` to allow manual triggering.
- Created `comment-trigger.yml` to listen for PR comments and trigger CI workflow.
- Configured `comment-trigger.yml` to trigger `ci.yaml` when a 'recheck' comment is added to a PR.