### PR TITLE
Add __init__.py

### DIFF
--- a/openstack_tests_list/__init__.py
+++ b/openstack_tests_list/__init__.py
@@ -1,0 +1,9 @@
+# openstack_tests_list/__init__.py
+
+# Import submodules or specific classes/functions to be accessible at the package level
+from .list_allowed import ListAllowedYaml
+from .list_skipped import ListSkippedYaml
+from .validate import ValidateYaml
+
+# Define package metadata
+__version__ = "0.1.0"

--- a/openstack_tests_list/default/__init__.py
+++ b/openstack_tests_list/default/__init__.py
@@ -1,0 +1,7 @@
+"""
+This module contains the default allowlist and skiplist configurations
+for the openstack-tests-list tool.
+"""
+
+from openstack_tests_list.list_allowed import get_allowed_tests
+from openstack_tests_list.list_skipped import get_skipped_tests


### PR DESCRIPTION
- Added __init__.py to default and openstack-tests-list directory to mark it as a Python package.
- Enables proper imports and package initialization.