### PR TITLE
Add new tempest image to tests-list

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM centos/centos:stream9
+USER root
+RUN dnf install -y gcc git jq make python3 python3-pip python-setuptools python-requests
+RUN git clone https://github.com/openstack-k8s-operators/repo-setup && \
+    pushd repo-setup && \
+    python3 setup.py install && \
+    popd && \
+    /usr/local/bin/repo-setup current-podified -b antelope
+
+RUN dnf update -y && \
+    dnf install -y python3-tempestconf openstack-tempest openstack-tempest-all && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf/*
+
+RUN git clone https://github.com/openstack-k8s-operators/openstack-tests-list.git && \
+    pushd openstack-tests-list && \
+    pip install . && \
+    popd
+
+RUN curl -s -L "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64" -o yq
+RUN chmod +x ./yq
+RUN mv ./yq /usr/local/bin
+RUN curl -s -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz | tar xvzf - -C /usr/local/bin oc
+RUN chmod +x /usr/local/bin/oc


### PR DESCRIPTION
Since this tool expects to use the openstack-tests-list to skip or execute the tempest tests, we wish to use new tempest image.